### PR TITLE
feature: add rpc client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,7 +625,7 @@ dependencies = [
  "ckb-crypto",
  "ckb-dao-utils",
  "ckb-error",
- "ckb-hash 0.108.0",
+ "ckb-hash",
  "ckb-jsonrpc-types",
  "ckb-pow",
  "ckb-rational",
@@ -695,7 +695,7 @@ version = "0.108.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00cbbc455b23748b32e06d16628a03e30d56ffa057f17093fdf5b42d4fb6c879"
 dependencies = [
- "ckb-fixed-hash-core 0.108.0",
+ "ckb-fixed-hash-core",
  "ckb-fixed-hash-macros",
 ]
 
@@ -711,23 +711,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "ckb-fixed-hash-core"
-version = "0.109.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c64c34f01b84f79753fff2cb4c0e2b45b9c71cf788eee32ec30aaf6e09e153e"
-dependencies = [
- "faster-hex",
- "serde",
- "thiserror",
-]
-
-[[package]]
 name = "ckb-fixed-hash-macros"
 version = "0.108.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cfc980ef88c217825172eb46df269f47890f5e78a38214416f13b3bd17a4b4"
 dependencies = [
- "ckb-fixed-hash-core 0.108.0",
+ "ckb-fixed-hash-core",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -738,16 +727,6 @@ name = "ckb-hash"
 version = "0.108.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d9b683e89ae4ffdd5aaf4172eab00b6bbe7ea24e2abf77d3eb850ba36e8983"
-dependencies = [
- "blake2b-ref",
- "blake2b-rs",
-]
-
-[[package]]
-name = "ckb-hash"
-version = "0.109.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e82f135970de1fe6728b243c11866f81cde1bc4610ea82d6673dabfaa211296"
 dependencies = [
  "blake2b-ref",
  "blake2b-rs",
@@ -834,7 +813,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9167b427f42874e68e20e6946d5211709979ff1d86c0061a71c2f6a6aa17659"
 dependencies = [
  "byteorder",
- "ckb-hash 0.108.0",
+ "ckb-hash",
  "ckb-types",
  "eaglesong",
  "log",
@@ -886,7 +865,7 @@ dependencies = [
  "byteorder",
  "ckb-chain-spec",
  "ckb-error",
- "ckb-hash 0.108.0",
+ "ckb-hash",
  "ckb-logger",
  "ckb-traits",
  "ckb-types",
@@ -907,7 +886,7 @@ dependencies = [
  "bytes",
  "ckb-crypto",
  "ckb-dao-utils",
- "ckb-hash 0.108.0",
+ "ckb-hash",
  "ckb-jsonrpc-types",
  "ckb-resource",
  "ckb-script",
@@ -966,7 +945,7 @@ dependencies = [
  "ckb-channel",
  "ckb-error",
  "ckb-fixed-hash",
- "ckb-hash 0.108.0",
+ "ckb-hash",
  "ckb-merkle-mountain-range",
  "ckb-occupied-capacity",
  "ckb-rational",
@@ -1102,6 +1081,7 @@ dependencies = [
  "async-trait",
  "axon-types",
  "bytes",
+ "ckb-jsonrpc-types",
  "ckb-rocksdb",
  "ckb-sdk",
  "ckb-types",
@@ -1744,11 +1724,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
+checksum = "0761a1b9491c4f2e3d66aa0f62d0fba0af9a0e2852e4d48ea506632a4b56e6aa"
 dependencies = [
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -2051,9 +2031,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.62"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68c16e1bfd491478ab155fd8b4896b86f9ede344949b641e61501e07c2b8b4d5"
+checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2885,9 +2865,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
 dependencies = [
  "unicode-ident",
 ]
@@ -3073,9 +3053,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.17"
+version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -3164,6 +3144,21 @@ dependencies = [
 [[package]]
 name = "rpc-client"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "ckb-jsonrpc-types",
+ "ckb-types",
+ "common",
+ "dashmap",
+ "jsonrpc-core",
+ "log",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+]
 
 [[package]]
 name = "rust-ini"
@@ -3294,9 +3289,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfdef77228a4c05dc94211441595746732131ad7f6530c6c18f045da7b7ab937"
+checksum = "b569c32c806ec3abdf3b5869fb8bf1e0d275a7c1c9b0b05603d9464632649edf"
 dependencies = [
  "cfg-if 1.0.0",
  "derive_more",
@@ -4222,8 +4217,7 @@ dependencies = [
  "async-trait",
  "axon-types",
  "bytes",
- "ckb-fixed-hash-core 0.109.0",
- "ckb-hash 0.109.0",
+ "ckb-hash",
  "ckb-sdk",
  "ckb-types",
  "common",
@@ -4309,9 +4303,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dad5567ad0cf5b760e5665964bec1b47dfd077ba8a2544b513f3556d3d239a2"
+checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
 dependencies = [
  "serde",
 ]
@@ -4378,9 +4372,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.85"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6cb788c4e39112fbe1822277ef6fb3c55cd86b95cb3d3c4c1c9597e4ac74b4"
+checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -4388,9 +4382,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.85"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e522ed4105a9d626d885b35d62501b30d9666283a5c8be12c14a8bdafe7822"
+checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
 dependencies = [
  "bumpalo",
  "log",
@@ -4403,9 +4397,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.35"
+version = "0.4.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "083abe15c5d88556b77bdf7aef403625be9e327ad37c62c4e4129af740168163"
+checksum = "2d1985d03709c53167ce907ff394f5316aa22cb4e12761295c5dc57dacb6297e"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -4415,9 +4409,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.85"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "358a79a0cb89d21db8120cbfb91392335913e4890665b1a7981d9e956903b434"
+checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4425,9 +4419,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.85"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4783ce29f09b9d93134d41297aded3a712b7b979e9c6f28c32cb88c973a94869"
+checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4438,15 +4432,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.85"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a901d592cafaa4d711bc324edfaff879ac700b19c3dfd60058d2b445be2691eb"
+checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
 
 [[package]]
 name = "web-sys"
-version = "0.3.62"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b5f940c7edfdc6d12126d98c9ef4d1b3d470011c47c76a6581df47ad9ba721"
+checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 axon-types = { git = "https://github.com/axonweb3/axon-contract", rev = "4f97620" }
 bytes = "1.0"
+ckb-jsonrpc-types = "0.108"
 ckb-sdk = "2.4"
 ckb-types = "0.108"
 dashmap = "5.4"

--- a/common/src/traits/axon_rpc_client.rs
+++ b/common/src/traits/axon_rpc_client.rs
@@ -1,0 +1,10 @@
+use async_trait::async_trait;
+
+use crate::types::ckb_rpc_client::Cell;
+
+#[async_trait]
+pub trait SubmitProcess {
+    fn is_closed(&self) -> bool;
+    // if false return, it means this cell process should be shutdown
+    async fn notify_axon(&mut self, cell: &Cell) -> bool;
+}

--- a/common/src/traits/ckb_rpc_client.rs
+++ b/common/src/traits/ckb_rpc_client.rs
@@ -1,0 +1,25 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use ckb_jsonrpc_types::{JsonBytes, Uint32};
+
+use ckb_jsonrpc_types::BlockNumber;
+
+use crate::types::ckb_rpc_client::{Cell, IndexerTip, Order, Pagination, RpcSearchKey, SearchKey};
+
+#[async_trait]
+pub trait CkbRpc {
+    async fn register(&self, search_key: RpcSearchKey, start: BlockNumber) -> Result<bool>;
+
+    async fn delete(&self, search_key: RpcSearchKey) -> Result<bool>;
+
+    async fn get_cells(
+        &self,
+        search_key: SearchKey,
+        order: Order,
+        limit: Uint32,
+        after: Option<JsonBytes>,
+    ) -> Result<Pagination<Cell>>;
+
+    // ckb indexer `get_indexer_tip`
+    async fn get_indexer_tip(&self) -> Result<IndexerTip>;
+}

--- a/common/src/traits/ckb_rpc_client.rs
+++ b/common/src/traits/ckb_rpc_client.rs
@@ -8,10 +8,6 @@ use crate::types::ckb_rpc_client::{Cell, IndexerTip, Order, Pagination, RpcSearc
 
 #[async_trait]
 pub trait CkbRpc {
-    async fn register(&self, search_key: RpcSearchKey, start: BlockNumber) -> Result<bool>;
-
-    async fn delete(&self, search_key: RpcSearchKey) -> Result<bool>;
-
     async fn get_cells(
         &self,
         search_key: SearchKey,
@@ -22,4 +18,11 @@ pub trait CkbRpc {
 
     // ckb indexer `get_indexer_tip`
     async fn get_indexer_tip(&self) -> Result<IndexerTip>;
+}
+
+#[async_trait]
+pub trait CkbSubscriptionRpc {
+    async fn register(&self, search_key: RpcSearchKey, start: BlockNumber) -> Result<bool>;
+
+    async fn delete(&self, search_key: RpcSearchKey) -> Result<bool>;
 }

--- a/common/src/traits/mod.rs
+++ b/common/src/traits/mod.rs
@@ -1,4 +1,6 @@
 pub mod api;
+pub mod axon_rpc_client;
+pub mod ckb_rpc_client;
 pub mod query;
 pub mod smt;
 pub mod tx_builder;

--- a/common/src/types/ckb_rpc_client.rs
+++ b/common/src/types/ckb_rpc_client.rs
@@ -1,0 +1,171 @@
+use ckb_jsonrpc_types::{
+    BlockNumber, Capacity, CellOutput, JsonBytes, OutPoint, Script, Uint32, Uint64,
+};
+use ckb_types::H256;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct IndexerTip {
+    pub block_hash:   H256,
+    pub block_number: BlockNumber,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum Order {
+    Desc,
+    Asc,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Pagination<T> {
+    pub objects:     Vec<T>,
+    pub last_cursor: JsonBytes,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum CellType {
+    Input,
+    Output,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct TxWithCell {
+    pub tx_hash:      H256,
+    pub block_number: BlockNumber,
+    pub tx_index:     Uint32,
+    pub io_index:     Uint32,
+    pub io_type:      CellType,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct TxWithCells {
+    pub tx_hash:      H256,
+    pub block_number: BlockNumber,
+    pub tx_index:     Uint32,
+    pub cells:        Vec<(CellType, Uint32)>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum Tx {
+    Ungrouped(TxWithCell),
+    Grouped(TxWithCells),
+}
+
+impl Tx {
+    pub fn tx_hash(&self) -> H256 {
+        match self {
+            Tx::Ungrouped(tx) => tx.tx_hash.clone(),
+            Tx::Grouped(tx) => tx.tx_hash.clone(),
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum IndexerScriptSearchMode {
+    /// Mode `prefix` search script with prefix
+    Prefix,
+    /// Mode `exact` search script with exact match
+    Exact,
+}
+
+impl Default for IndexerScriptSearchMode {
+    fn default() -> Self {
+        Self::Prefix
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct SearchKey {
+    pub script:               Script,
+    pub script_type:          ScriptType,
+    pub script_search_mode:   Option<IndexerScriptSearchMode>,
+    pub filter:               Option<SearchKeyFilter>,
+    pub with_data:            Option<bool>,
+    pub group_by_transaction: Option<bool>,
+}
+
+#[derive(Serialize, Deserialize, Default, Clone, Debug)]
+pub struct SearchKeyFilter {
+    pub script:                Option<Script>,
+    pub script_len_range:      Option<[Uint64; 2]>,
+    pub output_data_len_range: Option<[Uint64; 2]>,
+    pub output_capacity_range: Option<[Uint64; 2]>,
+    pub block_range:           Option<[BlockNumber; 2]>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ScriptType {
+    Lock,
+    Type,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct CellsCapacity {
+    pub capacity:     Capacity,
+    pub block_hash:   H256,
+    pub block_number: BlockNumber,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Cell {
+    pub output:       CellOutput,
+    pub output_data:  Option<JsonBytes>,
+    pub out_point:    OutPoint,
+    pub block_number: BlockNumber,
+    pub tx_index:     Uint32,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Hash, PartialEq, Eq)]
+pub struct RpcSearchKey {
+    pub script:             Script,
+    pub script_type:        ScriptType,
+    pub script_search_mode: Option<IndexerScriptSearchMode>,
+    pub filter:             Option<RpcSearchKeyFilter>,
+}
+
+impl RpcSearchKey {
+    pub fn into_key(self, block_range: Option<[Uint64; 2]>) -> SearchKey {
+        SearchKey {
+            script:               self.script,
+            script_type:          self.script_type,
+            filter:               if self.filter.is_some() {
+                self.filter.map(|f| f.into_filter(block_range))
+            } else {
+                Some(RpcSearchKeyFilter::default().into_filter(block_range))
+            },
+            script_search_mode:   self.script_search_mode,
+            with_data:            None,
+            group_by_transaction: Some(true),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default, Hash, PartialEq, Eq)]
+pub struct RpcSearchKeyFilter {
+    pub script:                Option<Script>,
+    pub script_len_range:      Option<[Uint64; 2]>,
+    pub output_data_len_range: Option<[Uint64; 2]>,
+    pub output_capacity_range: Option<[Uint64; 2]>,
+}
+
+impl RpcSearchKeyFilter {
+    fn into_filter(self, block_range: Option<[Uint64; 2]>) -> SearchKeyFilter {
+        SearchKeyFilter {
+            script: self.script,
+            script_len_range: self.script_len_range,
+            output_data_len_range: self.output_data_len_range,
+            output_capacity_range: self.output_capacity_range,
+            block_range,
+        }
+    }
+}
+
+pub trait TipState {
+    fn load(&self) -> &BlockNumber;
+    fn update(&mut self, current: BlockNumber);
+}

--- a/common/src/types/mod.rs
+++ b/common/src/types/mod.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod ckb_rpc_client;
 pub mod relation_db;
 pub mod smt;
 pub mod tx_builder;

--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -5,3 +5,21 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0"
+async-trait = "0.1"
+ckb-jsonrpc-types = "0.108"
+ckb-types = "0.108"
+dashmap = "5.4"
+jsonrpc-core = "18.0"
+log = "0.4"
+reqwest = { version = "0.11", features = ["json"], optional = true }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "1.0"
+tokio = { version = "1", features = ["time"] }
+
+common = { path = "../common" }
+
+[features]
+default = ["client"]
+client = ["reqwest"]

--- a/rpc-client/src/axon_client/mod.rs
+++ b/rpc-client/src/axon_client/mod.rs
@@ -1,0 +1,16 @@
+use async_trait::async_trait;
+use common::{traits::axon_rpc_client::SubmitProcess, types::ckb_rpc_client::Cell};
+
+pub struct RpcSubmit;
+
+#[async_trait]
+impl SubmitProcess for RpcSubmit {
+    fn is_closed(&self) -> bool {
+        false
+    }
+
+    async fn notify_axon(&mut self, cell: &Cell) -> bool {
+        println!("cell: {:?}", cell);
+        true
+    }
+}

--- a/rpc-client/src/ckb_client/cell_process.rs
+++ b/rpc-client/src/ckb_client/cell_process.rs
@@ -1,0 +1,64 @@
+use common::{
+    traits::{axon_rpc_client::SubmitProcess, ckb_rpc_client::CkbRpc},
+    types::ckb_rpc_client::{Order, RpcSearchKey, TipState},
+};
+
+pub struct CellProcess<T, S, R> {
+    key:      RpcSearchKey,
+    scan_tip: T,
+    rpc:      R,
+    process:  S,
+    stop:     bool,
+}
+
+impl<T, S, R> CellProcess<T, S, R>
+where
+    T: TipState,
+    S: SubmitProcess,
+    R: CkbRpc,
+{
+    pub fn new(key: RpcSearchKey, tip: T, rpc: R, process: S) -> Self {
+        Self {
+            key,
+            scan_tip: tip,
+            rpc,
+            process,
+            stop: false,
+        }
+    }
+
+    pub async fn run(&mut self) {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(8));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            if self.stop || self.process.is_closed() {
+                break;
+            }
+            self.scan(&mut interval).await;
+        }
+    }
+
+    async fn scan(&mut self, interval: &mut tokio::time::Interval) {
+        let indexer_tip = rpc_get!(self.rpc.get_indexer_tip());
+        let old_tip = *self.scan_tip.load();
+
+        if indexer_tip.block_number.value().saturating_sub(24) > old_tip.value() {
+            // use tip - 24 as new tip
+            let new_tip = indexer_tip.block_number.value().saturating_sub(24).into();
+
+            let search_key = self.key.clone().into_key(Some([old_tip, new_tip]));
+
+            let txs = rpc_get!(self
+                .rpc
+                .get_cells(search_key.clone(), Order::Asc, 1.into(), None));
+
+            if !txs.objects.is_empty() {
+                let cell = txs.objects.first().unwrap();
+                self.process.notify_axon(cell).await;
+            }
+            self.scan_tip.update(new_tip);
+        } else {
+            interval.tick().await;
+        }
+    }
+}

--- a/rpc-client/src/ckb_client/ckb_rpc_client.rs
+++ b/rpc-client/src/ckb_client/ckb_rpc_client.rs
@@ -1,0 +1,176 @@
+use crate::{axon_client::RpcSubmit, error::RpcError};
+use anyhow::Result;
+use async_trait::async_trait;
+use ckb_jsonrpc_types::{BlockNumber, JsonBytes, Uint32};
+use common::{
+    traits::ckb_rpc_client::CkbRpc,
+    types::ckb_rpc_client::{Cell, IndexerTip, Order, Pagination, RpcSearchKey, SearchKey},
+};
+use reqwest::{Client, Url};
+
+use std::{
+    future::Future,
+    io,
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicPtr, AtomicU64, Ordering},
+        Arc,
+    },
+};
+
+use crate::ckb_client::{
+    cell_process::CellProcess,
+    state_handle::GlobalState,
+    types::{ScanTip, ScanTipInner, State},
+};
+
+macro_rules! jsonrpc {
+    ($method:expr, $self:ident, $return:ty$(, $params:ident$(,)?)*) => {{
+        let old = $self.id.fetch_add(1, Ordering::AcqRel);
+        let data = format!(
+            r#"{{"id": {}, "jsonrpc": "2.0", "method": "{}", "params": {}}}"#,
+            old,
+            $method,
+            serde_json::to_value(($($params,)*)).unwrap()
+        );
+
+        let req_json: serde_json::Value = serde_json::from_str(&data).unwrap();
+
+        let c = $self.raw.post($self.ckb_uri.clone()).json(&req_json);
+        async {
+            let resp = c
+                .send()
+                .await.map_err(|e| RpcError::ConnectionAborted(io::Error::new(io::ErrorKind::ConnectionAborted, format!("{:?}", e))))?;
+            let output = resp
+                .json::<jsonrpc_core::response::Output>()
+                .await.map_err(|e| RpcError::InvalidData(io::Error::new(io::ErrorKind::InvalidData, format!("{:?}", e))))?;
+
+            match output {
+                jsonrpc_core::response::Output::Success(success) => {
+                    Ok(serde_json::from_value::<$return>(success.result).unwrap())
+                }
+                jsonrpc_core::response::Output::Failure(e) => {
+                    Err(RpcError::InvalidData(io::Error::new(io::ErrorKind::InvalidData, format!("{:?}", e))).into())
+                }
+            }
+        }
+    }}
+}
+
+// Default implementation of ckb Rpc client
+#[derive(Clone)]
+pub struct CkbClient {
+    raw:              Client,
+    ckb_uri:          Url,
+    id:               Arc<AtomicU64>,
+    pub cell_handles: Arc<dashmap::DashMap<RpcSearchKey, tokio::task::JoinHandle<()>>>,
+    pub state:        State,
+}
+
+impl CkbClient {
+    pub fn new(ckb_uri: &str, path: PathBuf) -> Self {
+        let ckb_uri = Url::parse(ckb_uri).expect("ckb uri, e.g. \"http://127.0.0.1:8114\"");
+        let mut global = GlobalState::new(path);
+        let state = global.state.clone();
+
+        let mut client = CkbClient {
+            raw: Client::new(),
+            ckb_uri,
+            id: Arc::new(AtomicU64::new(0)),
+            cell_handles: Arc::new(dashmap::DashMap::with_capacity(state.cell_states.len())),
+            state,
+        };
+        let cell_handles = global.spawn_cells(client.clone());
+        let _global_handle = tokio::spawn(async move { global.run().await });
+
+        client.cell_handles = cell_handles;
+
+        client
+    }
+
+    async fn register(&self, search_key: RpcSearchKey, start: BlockNumber) -> Result<bool> {
+        if self.state.cell_states.contains_key(&search_key) {
+            return Ok(false);
+        }
+        let indexer_tip = self.get_indexer_tip().await?;
+
+        if indexer_tip.block_number > start {
+            let scan_tip = ScanTip(Arc::new(ScanTipInner(AtomicPtr::new(Box::into_raw(
+                Box::new(start),
+            )))));
+
+            self.state
+                .cell_states
+                .insert(search_key.clone(), scan_tip.clone());
+
+            let mut cell_process =
+                CellProcess::new(search_key.clone(), scan_tip, self.clone(), RpcSubmit);
+
+            let handle = tokio::spawn(async move {
+                cell_process.run().await;
+            });
+
+            self.cell_handles.insert(search_key, handle);
+            return Ok(true);
+        }
+
+        Ok(false)
+    }
+
+    async fn delete(&self, search_key: RpcSearchKey) -> Result<bool> {
+        if self.state.cell_states.remove(&search_key).is_some() {
+            if let Some(handle) = self.cell_handles.get(&search_key) {
+                handle.abort();
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    pub fn get_cells(
+        &self,
+        search_key: SearchKey,
+        order: Order,
+        limit: Uint32,
+        after: Option<JsonBytes>,
+    ) -> impl Future<Output = Result<Pagination<Cell>>> {
+        jsonrpc!(
+            "get_cells",
+            self,
+            Pagination<Cell>,
+            search_key,
+            order,
+            limit,
+            after
+        )
+    }
+
+    pub fn get_indexer_tip(&self) -> impl Future<Output = Result<IndexerTip>> {
+        jsonrpc!("get_indexer_tip", self, IndexerTip)
+    }
+}
+
+#[async_trait]
+impl CkbRpc for CkbClient {
+    async fn register(&self, search_key: RpcSearchKey, start: BlockNumber) -> Result<bool> {
+        self.register(search_key, start).await
+    }
+
+    async fn delete(&self, search_key: RpcSearchKey) -> Result<bool> {
+        self.delete(search_key).await
+    }
+
+    async fn get_cells(
+        &self,
+        search_key: SearchKey,
+        order: Order,
+        limit: Uint32,
+        after: Option<JsonBytes>,
+    ) -> Result<Pagination<Cell>> {
+        self.get_cells(search_key, order, limit, after).await
+    }
+
+    async fn get_indexer_tip(&self) -> Result<IndexerTip> {
+        self.get_indexer_tip().await
+    }
+}

--- a/rpc-client/src/ckb_client/ckb_rpc_client.rs
+++ b/rpc-client/src/ckb_client/ckb_rpc_client.rs
@@ -1,28 +1,22 @@
-use crate::{axon_client::RpcSubmit, error::RpcError};
 use anyhow::Result;
 use async_trait::async_trait;
-use ckb_jsonrpc_types::{BlockNumber, JsonBytes, Uint32};
+use ckb_jsonrpc_types::{JsonBytes, Uint32};
 use common::{
     traits::ckb_rpc_client::CkbRpc,
-    types::ckb_rpc_client::{Cell, IndexerTip, Order, Pagination, RpcSearchKey, SearchKey},
+    types::ckb_rpc_client::{Cell, IndexerTip, Order, Pagination, SearchKey},
 };
 use reqwest::{Client, Url};
 
 use std::{
     future::Future,
     io,
-    path::PathBuf,
     sync::{
-        atomic::{AtomicPtr, AtomicU64, Ordering},
+        atomic::{AtomicU64, Ordering},
         Arc,
     },
 };
 
-use crate::ckb_client::{
-    cell_process::CellProcess,
-    state_handle::GlobalState,
-    types::{ScanTip, ScanTipInner, State},
-};
+use crate::error::RpcError;
 
 macro_rules! jsonrpc {
     ($method:expr, $self:ident, $return:ty$(, $params:ident$(,)?)*) => {{
@@ -59,72 +53,31 @@ macro_rules! jsonrpc {
 
 // Default implementation of ckb Rpc client
 #[derive(Clone)]
-pub struct CkbClient {
-    raw:              Client,
-    ckb_uri:          Url,
-    id:               Arc<AtomicU64>,
-    pub cell_handles: Arc<dashmap::DashMap<RpcSearchKey, tokio::task::JoinHandle<()>>>,
-    pub state:        State,
+pub struct CkbRpcClient {
+    raw:     Client,
+    ckb_uri: Url,
+    id:      Arc<AtomicU64>,
 }
 
-impl CkbClient {
-    pub fn new(ckb_uri: &str, path: PathBuf) -> Self {
+impl CkbRpcClient {
+    pub fn new(ckb_uri: &str) -> Self {
         let ckb_uri = Url::parse(ckb_uri).expect("ckb uri, e.g. \"http://127.0.0.1:8114\"");
-        let mut global = GlobalState::new(path);
-        let state = global.state.clone();
 
-        let mut client = CkbClient {
+        CkbRpcClient {
             raw: Client::new(),
             ckb_uri,
             id: Arc::new(AtomicU64::new(0)),
-            cell_handles: Arc::new(dashmap::DashMap::with_capacity(state.cell_states.len())),
-            state,
-        };
-        let cell_handles = global.spawn_cells(client.clone());
-        let _global_handle = tokio::spawn(async move { global.run().await });
-
-        client.cell_handles = cell_handles;
-
-        client
+        }
     }
 
-    async fn register(&self, search_key: RpcSearchKey, start: BlockNumber) -> Result<bool> {
-        if self.state.cell_states.contains_key(&search_key) {
-            return Ok(false);
+    pub fn new_with_client(ckb_uri: &str, raw: Client) -> Self {
+        let ckb_uri = Url::parse(ckb_uri).expect("ckb uri, e.g. \"http://127.0.0.1:8114\"");
+
+        CkbRpcClient {
+            raw,
+            ckb_uri,
+            id: Arc::new(AtomicU64::new(0)),
         }
-        let indexer_tip = self.get_indexer_tip().await?;
-
-        if indexer_tip.block_number > start {
-            let scan_tip = ScanTip(Arc::new(ScanTipInner(AtomicPtr::new(Box::into_raw(
-                Box::new(start),
-            )))));
-
-            self.state
-                .cell_states
-                .insert(search_key.clone(), scan_tip.clone());
-
-            let mut cell_process =
-                CellProcess::new(search_key.clone(), scan_tip, self.clone(), RpcSubmit);
-
-            let handle = tokio::spawn(async move {
-                cell_process.run().await;
-            });
-
-            self.cell_handles.insert(search_key, handle);
-            return Ok(true);
-        }
-
-        Ok(false)
-    }
-
-    async fn delete(&self, search_key: RpcSearchKey) -> Result<bool> {
-        if self.state.cell_states.remove(&search_key).is_some() {
-            if let Some(handle) = self.cell_handles.get(&search_key) {
-                handle.abort();
-                return Ok(true);
-            }
-        }
-        Ok(false)
     }
 
     pub fn get_cells(
@@ -151,15 +104,7 @@ impl CkbClient {
 }
 
 #[async_trait]
-impl CkbRpc for CkbClient {
-    async fn register(&self, search_key: RpcSearchKey, start: BlockNumber) -> Result<bool> {
-        self.register(search_key, start).await
-    }
-
-    async fn delete(&self, search_key: RpcSearchKey) -> Result<bool> {
-        self.delete(search_key).await
-    }
-
+impl CkbRpc for CkbRpcClient {
     async fn get_cells(
         &self,
         search_key: SearchKey,

--- a/rpc-client/src/ckb_client/ckb_subscription_client.rs
+++ b/rpc-client/src/ckb_client/ckb_subscription_client.rs
@@ -1,0 +1,89 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use common::traits::ckb_rpc_client::CkbSubscriptionRpc;
+use std::path::PathBuf;
+use std::sync::{atomic::AtomicPtr, Arc};
+
+use ckb_jsonrpc_types::BlockNumber;
+use common::types::ckb_rpc_client::RpcSearchKey;
+
+use crate::axon_client::RpcSubmit;
+use crate::ckb_client::{
+    cell_process::CellProcess,
+    ckb_rpc_client::CkbRpcClient,
+    state_handle::GlobalState,
+    types::{ScanTip, ScanTipInner, State},
+};
+
+pub struct CkbSubscriptionClient {
+    cell_handles: Arc<dashmap::DashMap<RpcSearchKey, tokio::task::JoinHandle<()>>>,
+    state:        State,
+    client:       CkbRpcClient,
+}
+
+impl CkbSubscriptionClient {
+    pub fn new(ckb_uri: &str, path: PathBuf) -> Self {
+        let client = CkbRpcClient::new(ckb_uri);
+        let mut global = GlobalState::new(path);
+        let state = global.state.clone();
+
+        let cell_handles = global.spawn_cells(client.clone());
+        let _global_handle = tokio::spawn(async move { global.run().await });
+
+        Self {
+            cell_handles,
+            state,
+            client,
+        }
+    }
+
+    async fn register(&self, search_key: RpcSearchKey, start: BlockNumber) -> Result<bool> {
+        if self.state.cell_states.contains_key(&search_key) {
+            return Ok(false);
+        }
+        let indexer_tip = self.client.get_indexer_tip().await?;
+
+        if indexer_tip.block_number > start {
+            let scan_tip = ScanTip(Arc::new(ScanTipInner(AtomicPtr::new(Box::into_raw(
+                Box::new(start),
+            )))));
+
+            self.state
+                .cell_states
+                .insert(search_key.clone(), scan_tip.clone());
+
+            let mut cell_process =
+                CellProcess::new(search_key.clone(), scan_tip, self.client.clone(), RpcSubmit);
+
+            let handle = tokio::spawn(async move {
+                cell_process.run().await;
+            });
+
+            self.cell_handles.insert(search_key, handle);
+            return Ok(true);
+        }
+
+        Ok(false)
+    }
+
+    async fn delete(&self, search_key: RpcSearchKey) -> Result<bool> {
+        if self.state.cell_states.remove(&search_key).is_some() {
+            if let Some(handle) = self.cell_handles.get(&search_key) {
+                handle.abort();
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+}
+
+#[async_trait]
+impl CkbSubscriptionRpc for CkbSubscriptionClient {
+    async fn register(&self, search_key: RpcSearchKey, start: BlockNumber) -> Result<bool> {
+        self.register(search_key, start).await
+    }
+
+    async fn delete(&self, search_key: RpcSearchKey) -> Result<bool> {
+        self.delete(search_key).await
+    }
+}

--- a/rpc-client/src/ckb_client/mod.rs
+++ b/rpc-client/src/ckb_client/mod.rs
@@ -12,5 +12,6 @@ macro_rules! rpc_get {
 pub mod cell_process;
 #[cfg(feature = "client")]
 pub mod ckb_rpc_client;
+pub mod ckb_subscription_client;
 mod state_handle;
 pub mod types;

--- a/rpc-client/src/ckb_client/mod.rs
+++ b/rpc-client/src/ckb_client/mod.rs
@@ -1,0 +1,16 @@
+macro_rules! rpc_get {
+    ($method:expr) => {{
+        loop {
+            match $method.await {
+                Ok(r) => break r,
+                Err(e) => panic!("rpc error: {:?}", e),
+            }
+        }
+    }};
+}
+
+pub mod cell_process;
+#[cfg(feature = "client")]
+pub mod ckb_rpc_client;
+mod state_handle;
+pub mod types;

--- a/rpc-client/src/ckb_client/state_handle.rs
+++ b/rpc-client/src/ckb_client/state_handle.rs
@@ -7,7 +7,7 @@ use std::{
 
 use common::types::ckb_rpc_client::RpcSearchKey;
 
-use crate::ckb_client::{cell_process::CellProcess, ckb_rpc_client::CkbClient, types::State};
+use crate::ckb_client::{cell_process::CellProcess, ckb_rpc_client::CkbRpcClient, types::State};
 
 use crate::axon_client::RpcSubmit;
 
@@ -61,7 +61,7 @@ impl GlobalState {
 
     pub fn spawn_cells(
         &self,
-        client: CkbClient,
+        client: CkbRpcClient,
     ) -> Arc<dashmap::DashMap<RpcSearchKey, tokio::task::JoinHandle<()>>> {
         if !self.state.cell_states.is_empty() {
             for kv in self.state.cell_states.iter() {

--- a/rpc-client/src/ckb_client/state_handle.rs
+++ b/rpc-client/src/ckb_client/state_handle.rs
@@ -1,0 +1,138 @@
+use std::{
+    fs::{copy, create_dir_all, remove_file, rename, File, OpenOptions},
+    io::Write,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use common::types::ckb_rpc_client::RpcSearchKey;
+
+use crate::ckb_client::{cell_process::CellProcess, ckb_rpc_client::CkbClient, types::State};
+
+use crate::axon_client::RpcSubmit;
+
+pub struct GlobalState {
+    pub state:        State,
+    pub path:         PathBuf,
+    pub cell_handles: Arc<dashmap::DashMap<RpcSearchKey, tokio::task::JoinHandle<()>>>,
+}
+
+impl Drop for GlobalState {
+    fn drop(&mut self) {
+        self.dump_to_dir(self.path.clone())
+    }
+}
+
+impl GlobalState {
+    pub fn new(path: PathBuf) -> Self {
+        let state = Self::load_from_dir(path.clone());
+
+        Self {
+            cell_handles: Arc::new(dashmap::DashMap::with_capacity(state.cell_states.len())),
+            state,
+            path,
+        }
+    }
+
+    pub async fn run(&mut self) {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        loop {
+            interval.tick().await;
+
+            // clean shutdown task
+            let mut shutdown_task = Vec::new();
+            self.cell_handles.retain(|k, v| {
+                if v.is_finished() {
+                    shutdown_task.push(k.clone());
+                    false
+                } else {
+                    true
+                }
+            });
+            shutdown_task.into_iter().for_each(|k| {
+                self.state.cell_states.remove(&k);
+            });
+
+            self.dump_to_dir(self.path.clone());
+        }
+    }
+
+    pub fn spawn_cells(
+        &self,
+        client: CkbClient,
+    ) -> Arc<dashmap::DashMap<RpcSearchKey, tokio::task::JoinHandle<()>>> {
+        if !self.state.cell_states.is_empty() {
+            for kv in self.state.cell_states.iter() {
+                let mut cell_process = CellProcess::new(
+                    kv.key().clone(),
+                    kv.value().clone(),
+                    client.clone(),
+                    RpcSubmit,
+                );
+
+                let handle = tokio::spawn(async move {
+                    cell_process.run().await;
+                });
+                self.cell_handles.insert(kv.key().clone(), handle);
+            }
+        }
+        Arc::<
+            dashmap::DashMap<
+                common::types::ckb_rpc_client::RpcSearchKey,
+                tokio::task::JoinHandle<()>,
+            >,
+        >::clone(&self.cell_handles)
+    }
+
+    fn load_from_dir(path: PathBuf) -> State {
+        let db_path = path.join("scan_state");
+
+        match File::open(&db_path) {
+            Ok(f) => serde_json::from_reader(f).unwrap_or(State {
+                cell_states: Default::default(),
+            }),
+            Err(e) => {
+                log::warn!(
+                    "Failed to open state db, file: {:?}, error: {:?}",
+                    db_path,
+                    e
+                );
+                State {
+                    cell_states: Default::default(),
+                }
+            }
+        }
+    }
+
+    fn dump_to_dir<P: AsRef<Path>>(&self, path: P) {
+        // create dir
+        create_dir_all(&path).unwrap();
+        // dump file to a temporary sub-directory
+        let tmp_dir = path.as_ref().join("tmp");
+        create_dir_all(&tmp_dir).unwrap();
+        let tmp_scan_state = tmp_dir.join("scan_state");
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .append(false)
+            .open(&tmp_scan_state)
+            .unwrap();
+        // empty file and dump the json string to it
+        file.set_len(0)
+            .and_then(|_| serde_json::to_string(&self.state).map_err(Into::into))
+            .and_then(|json_string| file.write_all(json_string.as_bytes()))
+            .and_then(|_| file.sync_all())
+            .unwrap();
+        move_file(tmp_scan_state, path.as_ref().join("scan_state")).unwrap();
+    }
+}
+
+fn move_file<P: AsRef<Path>>(src: P, dst: P) -> Result<(), std::io::Error> {
+    if rename(&src, &dst).is_err() {
+        copy(&src, &dst)?;
+        remove_file(&src)?;
+    }
+    Ok(())
+}

--- a/rpc-client/src/ckb_client/types.rs
+++ b/rpc-client/src/ckb_client/types.rs
@@ -1,0 +1,108 @@
+use std::sync::{
+    atomic::{AtomicPtr, Ordering},
+    Arc,
+};
+
+use ckb_jsonrpc_types::BlockNumber;
+use serde::{ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer};
+
+use common::types::ckb_rpc_client::{RpcSearchKey, TipState};
+
+#[derive(Clone)]
+pub struct State {
+    pub cell_states: Arc<dashmap::DashMap<RpcSearchKey, ScanTip>>,
+}
+
+impl Serialize for State {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("State", 2)?;
+        state.serialize_field(
+            "cell_states",
+            &self
+                .cell_states
+                .iter()
+                .map(|kv| (kv.key().clone(), kv.value().clone()))
+                .collect::<Vec<_>>(),
+        )?;
+        state.end()
+    }
+}
+
+impl<'a> Deserialize<'a> for State {
+    fn deserialize<D>(deserializer: D) -> Result<State, D::Error>
+    where
+        D: Deserializer<'a>,
+    {
+        #[derive(Deserialize, Serialize)]
+        struct StateVisitor {
+            cell_states: Vec<(RpcSearchKey, ScanTip)>,
+        }
+
+        let v: StateVisitor = Deserialize::deserialize(deserializer)?;
+        Ok(State {
+            cell_states: Arc::new(v.cell_states.into_iter().collect()),
+        })
+    }
+}
+
+pub struct ScanTipInner(pub AtomicPtr<BlockNumber>);
+
+pub struct ScanTip(pub Arc<ScanTipInner>);
+
+impl Drop for ScanTipInner {
+    fn drop(&mut self) {
+        unsafe { drop(Box::from_raw(self.0.load(Ordering::Relaxed))) }
+    }
+}
+
+impl Clone for ScanTip {
+    fn clone(&self) -> Self {
+        ScanTip(Arc::new(ScanTipInner(AtomicPtr::new(Box::into_raw(
+            Box::new(*self.load()),
+        )))))
+    }
+}
+
+impl TipState for ScanTip {
+    fn load(&self) -> &BlockNumber {
+        unsafe { &*self.0 .0.load(Ordering::Acquire) }
+    }
+
+    fn update(&mut self, current: BlockNumber) {
+        let raw = self
+            .0
+             .0
+            .swap(Box::into_raw(Box::new(current)), Ordering::AcqRel);
+
+        unsafe {
+            drop(Box::from_raw(raw));
+        }
+    }
+}
+
+impl Serialize for ScanTip {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let inner = unsafe { &*self.0 .0.load(Ordering::Acquire) };
+
+        inner.serialize(serializer)
+    }
+}
+
+impl<'a> Deserialize<'a> for ScanTip {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'a>,
+    {
+        let inner = BlockNumber::deserialize(deserializer)?;
+
+        Ok(ScanTip(Arc::new(ScanTipInner(AtomicPtr::new(
+            Box::into_raw(Box::new(inner)),
+        )))))
+    }
+}

--- a/rpc-client/src/error.rs
+++ b/rpc-client/src/error.rs
@@ -1,0 +1,11 @@
+use std::io;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum RpcError {
+    #[error("RocksDB creation error {0}")]
+    ConnectionAborted(io::Error),
+
+    #[error("jsonrpc output failure {0}")]
+    InvalidData(io::Error),
+}

--- a/rpc-client/src/lib.rs
+++ b/rpc-client/src/lib.rs
@@ -1,14 +1,3 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+pub mod axon_client;
+pub mod ckb_client;
+pub mod error;

--- a/tx-builder/Cargo.toml
+++ b/tx-builder/Cargo.toml
@@ -9,8 +9,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 axon-types = { git = "https://github.com/axonweb3/axon-contract", rev = "4f97620" }
 bytes = "1.0"
-ckb-fixed-hash-core = "0.109"
-ckb-hash = "0.109"
+ckb-hash = "0.108"
 ckb-sdk = "2.4"
 ckb-types = "0.108"
 common = { path = "../common" }


### PR DESCRIPTION
This pr adds both the axon client which handles communication with axon and the ckb client which handles rpc requests to ckb_indexer.

The axon client is not fully finished. The endpoint to send the metadata to axon is left unimplemented so far.