### PR TITLE
chore: upgrade rocksdb version to v0.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-librocksdb-sys"
-version = "7.7.3"
+version = "8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb64bb11f8d53b9abb526b7e9d3c5fb437a8101e4210d540d2bcee0d18055313"
+checksum = "5d9bc1ea9ab886ecbf48bc4ade6d383ba56cf3da198b6a51620736daf74b683c"
 dependencies = [
  "bindgen",
  "cc",
@@ -868,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-rocksdb"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9d412caf8a7fe9080bf2c66209e1b6d9aab336c417b336adde47e184c78c41"
+checksum = "c2331a8580072e2991e77277d2c3e999c8df0d00b16188a77e561e45a4597769"
 dependencies = [
  "ckb-librocksdb-sys",
  "libc",
@@ -1113,7 +1113,6 @@ dependencies = [
  "parking_lot 0.12.1",
  "sea-orm",
  "serde",
- "smt-rocksdb-store",
  "sparse-merkle-tree",
  "thiserror",
  "tokio",
@@ -3695,7 +3694,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 [[package]]
 name = "smt-rocksdb-store"
 version = "0.1.0"
-source = "git+https://github.com/axonweb3/smt-rocksdb-store.git?rev=9047428#90474282c9a435faeba7c78c8ac392f58f1968d8"
+source = "git+https://github.com/axonweb3/smt-rocksdb-store.git?rev=4d4ea31#4d4ea315ee84c5e5f1e6c41df2ea918b5226b24e"
 dependencies = [
  "ckb-rocksdb",
  "sparse-merkle-tree",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -17,10 +17,9 @@ ethereum-types = { version = "0.14", features = ["arbitrary", "codec", "rlp", "s
 lazy_static = "1.4"
 molecule = "0.7"
 parking_lot = "0.12"
-rocksdb = { package = "ckb-rocksdb", version = "0.19", default-features = false, features = ["snappy", "march-native"] }
+rocksdb = { package = "ckb-rocksdb", version = "0.20", default-features = false, features = ["snappy", "march-native"] }
 sea-orm = { version = "0.11", features = ["runtime-tokio-native-tls", "sqlx-sqlite", "macros"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
-smt-rocksdb-store = { git = "https://github.com/axonweb3/smt-rocksdb-store.git", rev = "9047428" }
 sparse-merkle-tree = "0.6"
 thiserror = "1.0"
 tokio = { version = "1.20", features = ["macros", "rt-multi-thread"] }

--- a/common/src/types/smt.rs
+++ b/common/src/types/smt.rs
@@ -1,8 +1,8 @@
 use crate::types::H160;
+
 use derive_more::Display;
 use rocksdb::DBVector;
-use smt_rocksdb_store::cf_store::{ColumnFamilyStore, ColumnFamilyStoreMultiTree};
-use sparse_merkle_tree::{blake2b::Blake2bHasher, traits::Value, SparseMerkleTree, H256};
+use sparse_merkle_tree::{traits::Value, H256};
 
 lazy_static::lazy_static! {
     pub static ref TOP_SMT_PREFIX: &'static str = "top_smt";
@@ -11,14 +11,6 @@ lazy_static::lazy_static! {
     pub static ref REWARD_TABLE: &'static str = "reward";
     pub static ref PROPOSAL_TABLE: &'static str = "proposal";
 }
-
-/// Single SMT
-pub type ColumnFamilyStoreSMT<'a, T, W> =
-    SparseMerkleTree<Blake2bHasher, LeafValue, ColumnFamilyStore<'a, T, W>>;
-
-/// Multi SMT
-pub type ColumnFamilyStoreMultiSMT<'a, T, W> =
-    SparseMerkleTree<Blake2bHasher, LeafValue, ColumnFamilyStoreMultiTree<'a, T, W>>;
 
 pub type Amount = u128;
 pub type Epoch = u64;

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -15,7 +15,7 @@ ethereum-types = { version = "0.14", features = ["arbitrary", "codec", "rlp", "s
 lazy_static = "1.4"
 log = "0.4"
 parking_lot = "0.12"
-rocksdb = { package = "ckb-rocksdb", version = "0.19", features = ["snappy", "march-native"] }
+rocksdb = { package = "ckb-rocksdb", version = "0.20", features = ["snappy", "march-native"] }
 sea-orm = { version = "0.11", features = ["runtime-tokio-native-tls", "sqlx-sqlite", "macros"] }
 sparse-merkle-tree = { version = "0.6", feautres = ["trie"] }
 thiserror = "1.0"
@@ -24,7 +24,7 @@ tokio = { version = "1.20", features = ["macros", "rt-multi-thread"] }
 common = { path = "../common" }
 migration = { path = "./migration" }
 
-smt-rocksdb-store = { git = "https://github.com/axonweb3/smt-rocksdb-store.git", rev = "9047428", features = ["trie"] }
+smt-rocksdb-store = { git = "https://github.com/axonweb3/smt-rocksdb-store.git", rev = "4d4ea31", features = ["trie"] }
 
 [features]
 default = []

--- a/storage/src/smt/mod.rs
+++ b/storage/src/smt/mod.rs
@@ -7,19 +7,27 @@ use async_trait::async_trait;
 
 use rocksdb::{prelude::*, Direction, IteratorMode, OptimisticTransactionDB};
 use smt_rocksdb_store::cf_store::{ColumnFamilyStore, ColumnFamilyStoreMultiTree};
-use sparse_merkle_tree::{traits::Value, H256};
+use sparse_merkle_tree::{blake2b::Blake2bHasher, traits::Value, SparseMerkleTree, H256};
 
 use common::{
     traits::smt::{DelegateSmtStorage, ProposalSmtStorage, RewardSmtStorage, StakeSmtStorage},
     types::smt::{
-        Address, Amount, CFSuffixType, ColumnFamilyStoreMultiSMT, ColumnFamilyStoreSMT, Delegator,
-        Epoch, LeafValue, Proof, ProposalCount, Root, SmtKeyEncode, SmtPrefixType, SmtValueEncode,
-        Staker, UserAmount, Validator, DELEGATOR_TABLE, PROPOSAL_TABLE, REWARD_TABLE, STAKER_TABLE,
+        Address, Amount, CFSuffixType, Delegator, Epoch, LeafValue, Proof, ProposalCount, Root,
+        SmtKeyEncode, SmtPrefixType, SmtValueEncode, Staker, UserAmount, Validator,
+        DELEGATOR_TABLE, PROPOSAL_TABLE, REWARD_TABLE, STAKER_TABLE,
     },
 };
 
 use crate::error::StorageError;
 use crate::{create_table_cfs, get_cf_prefix, get_smt, get_sub_leaves, keys_to_h256};
+
+/// Single SMT
+pub type ColumnFamilyStoreSMT<'a, T, W> =
+    SparseMerkleTree<Blake2bHasher, LeafValue, ColumnFamilyStore<'a, T, W>>;
+
+/// Multi SMT
+pub type ColumnFamilyStoreMultiSMT<'a, T, W> =
+    SparseMerkleTree<Blake2bHasher, LeafValue, ColumnFamilyStoreMultiTree<'a, T, W>>;
 
 pub struct SmtManager {
     db: Arc<OptimisticTransactionDB>,


### PR DESCRIPTION
Upgrade rocksdb version to v0.20 that fix compile in gcc 13,1