### PR TITLE
fix: fetch data by prefix will get more data than needed

### DIFF
--- a/storage/src/tests/mod.rs
+++ b/storage/src/tests/mod.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, vec};
+use std::{fs, path::PathBuf, vec};
 
 use ckb_types::h160;
 
@@ -15,6 +15,8 @@ static ROCKSDB_PATH: &str = "./free-space/smt";
 async fn test_stake_functions() {
     let mut path = PathBuf::from(ROCKSDB_PATH);
     path.push("stake");
+    fs::remove_dir_all(path.clone()).unwrap();
+
     let smt_manager = SmtManager::new(path);
     let staker = [5u8; 20].into();
     let epoch = 1;
@@ -72,6 +74,7 @@ async fn test_stake_functions() {
 async fn test_delegate_smt() {
     let mut path = PathBuf::from(ROCKSDB_PATH);
     path.push("delegate1");
+    fs::remove_dir_all(path.clone()).unwrap();
 
     let smt_manager = SmtManager::new(path);
     let stakers: Vec<Staker> = vec![
@@ -110,9 +113,57 @@ async fn test_delegate_smt() {
 }
 
 #[tokio::test]
+async fn test_delegate_smt_no_extra_data() {
+    let mut path = PathBuf::from(ROCKSDB_PATH);
+    path.push("delegate2");
+    fs::remove_dir_all(path.clone()).unwrap();
+
+    let smt_manager = SmtManager::new(path);
+    let stakers: Vec<Staker> = vec![
+        h160!("0x11999a8db6049687978cf396ee4599876a12d960").0.into(),
+        h160!("0xca00b6a1b34b7fcf087e9f81dfd63724c337b6fe").0.into(),
+        h160!("0x5d164cf753be3272a22cbaf60c94f3e8e3b20878").0.into(),
+    ];
+    let delegator = h160!("0x25cdf0e188c0ed538709ad1b696b52595202b02b").0.into();
+    let epoch = 2;
+    let amount = 10u128;
+
+    let delegators = vec![UserAmount {
+        user: delegator,
+        amount,
+        is_increase: true,
+    }];
+
+    for staker in stakers.clone() {
+        let smt = DelegateSmtStorage::get_sub_leaves(&smt_manager, epoch, staker)
+            .await
+            .unwrap();
+        assert_eq!(0, smt.len());
+
+        DelegateSmtStorage::insert(&smt_manager, epoch, staker, delegators.clone())
+            .await
+            .unwrap();
+        let result = DelegateSmtStorage::get_amount(&smt_manager, epoch, staker, delegator)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(result, amount);
+
+        let smt = DelegateSmtStorage::get_sub_leaves(&smt_manager, epoch, staker)
+            .await
+            .unwrap();
+        for (user, amount) in smt.into_iter() {
+            assert_eq!(amount, 10);
+            assert_eq!(user, delegator);
+        }
+    }
+}
+
+#[tokio::test]
 async fn test_delegate_functions() {
     let mut path = PathBuf::from(ROCKSDB_PATH);
     path.push("delegate");
+    fs::remove_dir_all(path.clone()).unwrap();
 
     let smt_manager = SmtManager::new(path);
     let staker = [5u8; 20].into();
@@ -172,6 +223,8 @@ async fn test_delegate_functions() {
 async fn test_reward_functions() {
     let mut path = PathBuf::from(ROCKSDB_PATH);
     path.push("reward");
+    fs::remove_dir_all(path.clone()).unwrap();
+
     let smt_manager = SmtManager::new(path);
     let address = [5u8; 20].into();
     let epoch = 1;
@@ -191,6 +244,8 @@ async fn test_reward_functions() {
 async fn test_proposal_functions() {
     let mut path = PathBuf::from(ROCKSDB_PATH);
     path.push("proposal");
+    fs::remove_dir_all(path.clone()).unwrap();
+
     let smt_manager = SmtManager::new(path);
     let validator = [5u8; 20].into();
     let epoch = 1;

--- a/tx-builder/src/ckb/define/scripts.rs
+++ b/tx-builder/src/ckb/define/scripts.rs
@@ -178,7 +178,7 @@ lazy_static::lazy_static! {
     pub static ref METADATA_TYPE_TESTNET: Script = Script {
         code_hash: h256!("0x2c8f63ac17c1e5e660dddbf49e88994cd1c49d4d6e99e7a7fd3f8879700d3cd1"),
         hash_type: ScriptHashType::Type,
-        tx_hash: h256!("0x5cdb07735e0e1bf0a845945c580441cf7d85c8d00980a3cfa2b8040e18369cc8"),
+        tx_hash: h256!("0xeb1e9be549b9e7fd2acb0c78abacc29b321f40c2d964c854ab0fd48d8111a3fc"),
         index: 0,
         dep_type: DepType::Code,
     };


### PR DESCRIPTION
The IteratorMode::From mode starts the iterator at the first key that is greater than or equal to the provided key.  
https://github.com/rust-rocksdb/rust-rocksdb/issues/370)(https://github.com/rust-rocksdb/rust-rocksdb/issues/370   
If there are keys that sort after your prefix but are not part of it, they will still be included in the iteration.   
https://bleepcoder.com/rust-rocksdb/378811240/the-prefix-iterator-behaves-weirdly 