### PR TITLE
refactor: change AT cell lock script from OmniLock to Secp256k1

### DIFF
--- a/storage/src/tests/mod.rs
+++ b/storage/src/tests/mod.rs
@@ -15,7 +15,9 @@ static ROCKSDB_PATH: &str = "./free-space/smt";
 async fn test_stake_functions() {
     let mut path = PathBuf::from(ROCKSDB_PATH);
     path.push("stake");
-    fs::remove_dir_all(path.clone()).unwrap();
+    if path.exists() {
+        fs::remove_dir_all(path.clone()).unwrap();
+    }
 
     let smt_manager = SmtManager::new(path);
     let staker = [5u8; 20].into();
@@ -74,7 +76,9 @@ async fn test_stake_functions() {
 async fn test_delegate_smt() {
     let mut path = PathBuf::from(ROCKSDB_PATH);
     path.push("delegate1");
-    fs::remove_dir_all(path.clone()).unwrap();
+    if path.exists() {
+        fs::remove_dir_all(path.clone()).unwrap();
+    }
 
     let smt_manager = SmtManager::new(path);
     let stakers: Vec<Staker> = vec![
@@ -116,7 +120,9 @@ async fn test_delegate_smt() {
 async fn test_delegate_smt_no_extra_data() {
     let mut path = PathBuf::from(ROCKSDB_PATH);
     path.push("delegate2");
-    fs::remove_dir_all(path.clone()).unwrap();
+    if path.exists() {
+        fs::remove_dir_all(path.clone()).unwrap();
+    }
 
     let smt_manager = SmtManager::new(path);
     let stakers: Vec<Staker> = vec![
@@ -163,7 +169,9 @@ async fn test_delegate_smt_no_extra_data() {
 async fn test_delegate_functions() {
     let mut path = PathBuf::from(ROCKSDB_PATH);
     path.push("delegate");
-    fs::remove_dir_all(path.clone()).unwrap();
+    if path.exists() {
+        fs::remove_dir_all(path.clone()).unwrap();
+    }
 
     let smt_manager = SmtManager::new(path);
     let staker = [5u8; 20].into();
@@ -223,7 +231,9 @@ async fn test_delegate_functions() {
 async fn test_reward_functions() {
     let mut path = PathBuf::from(ROCKSDB_PATH);
     path.push("reward");
-    fs::remove_dir_all(path.clone()).unwrap();
+    if path.exists() {
+        fs::remove_dir_all(path.clone()).unwrap();
+    }
 
     let smt_manager = SmtManager::new(path);
     let address = [5u8; 20].into();
@@ -244,7 +254,9 @@ async fn test_reward_functions() {
 async fn test_proposal_functions() {
     let mut path = PathBuf::from(ROCKSDB_PATH);
     path.push("proposal");
-    fs::remove_dir_all(path.clone()).unwrap();
+    if path.exists() {
+        fs::remove_dir_all(path.clone()).unwrap();
+    }
 
     let smt_manager = SmtManager::new(path);
     let validator = [5u8; 20].into();

--- a/tx-builder/src/ckb/helper/ckb/basic_scripts.rs
+++ b/tx-builder/src/ckb/helper/ckb/basic_scripts.rs
@@ -78,6 +78,26 @@ impl Secp256k1 {
             ),
         }
     }
+
+    pub fn lock(args: Bytes) -> Script {
+        match **NETWORK_TYPE.load() {
+            NetworkType::Mainnet => script!(
+                &SECP2561_BLAKE160_MAINNET.code_hash,
+                SECP2561_BLAKE160_MAINNET.hash_type,
+                args
+            ),
+            NetworkType::Testnet => script!(
+                &SECP2561_BLAKE160_TESTNET.code_hash,
+                SECP2561_BLAKE160_TESTNET.hash_type,
+                args
+            ),
+            NetworkType::Devnet => script!(
+                &SECP2561_BLAKE160_DEVNET.code_hash,
+                SECP2561_BLAKE160_DEVNET.hash_type,
+                args
+            ),
+        }
+    }
 }
 
 impl TypeId {

--- a/tx-builder/src/ckb/reward.rs
+++ b/tx-builder/src/ckb/reward.rs
@@ -141,7 +141,7 @@ where
                 .build_exact_capacity(Capacity::bytes(outputs_data[1].len())?)?,
             // AT cell
             CellOutput::new_builder()
-                .lock(OmniEth::lock(&self.user))
+                .lock(Secp256k1::lock(Bytes::from(self.user.0.to_vec())))
                 .type_(Some(Xudt::type_(&self.type_ids.xudt_owner.pack())).pack())
                 .build_exact_capacity(Capacity::bytes(outputs_data[2].len())?)?,
         ];


### PR DESCRIPTION
1. In a claim reward tx, the lock script of output normal AT cell should be Secp256k1 instead of Omni lock.    
Because the reward contract only supports Secp256k1 lock yet.  
2. In unit test, we can remove the dir of Rockdb only if it existed already.